### PR TITLE
include README.md in Kitspace pages

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -7,6 +7,7 @@ multi:
         bom: Open Book Feather/1-click-bom.csv
         gerbers: Open Book Feather/CAMOutputs/OSO-BOOK-A1-05_2020-06-05/GerberFiles/
         color: black
+        readme: README.md
     eBook-Wing:
         summary: A FeatherWing with most of the functionality of the Open Book, but simpler to build
         eda:
@@ -15,3 +16,4 @@ multi:
         bom: eBook Feather Wing/1-click-bom.csv
         gerbers: eBook Feather Wing/CAMOutputs/OSO-BOWI-A1-05_2020-02-13/GerberFiles/
         color: blue
+        readme: README.md


### PR DESCRIPTION
We don't currently pick this up automatically for multi projects. You can point it at another readme if you have a board-specific one.