### PR TITLE
Use IA link for video walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Open Book is open source hardware: you should feel free to build one yoursel
 
 Please steal this book.
 
-I plan to add more documentation in the new year, but until then, [this half-hour video walks through building one Open Book board in real-time](https://twitter.com/i/broadcasts/1OyKAVPjrvaGb).
+I plan to add more documentation in the new year, but until then, [this half-hour video walks through building one Open Book board in real-time](https://archive.org/details/live-from-the-oddly-specific-kitchen-table-assembling-the-pcbway-official-sponso).
 
 ### Forking and tweaking the boards
 


### PR DESCRIPTION
Twitter/X video is defunct; docs should point to archived version on Internet Archive.

Resolves #89 